### PR TITLE
update litecanvas and asset loader plugin

### DIFF
--- a/findluigi/game.html
+++ b/findluigi/game.html
@@ -16,9 +16,9 @@
     </head>
     <body>
         <script
-            src="https://unpkg.com/litecanvas@0.74.0/dist/dist.min.js"></script>
+            src="https://unpkg.com/litecanvas@0.100/dist/dist.min.js"></script>
         <script
-            src="https://unpkg.com/@litecanvas/plugin-asset-loader@0.14.0/dist/dist.min.js"></script>
+            src="https://unpkg.com/@litecanvas/plugin-asset-loader@0.16/dist/dist.min.js"></script>
         <script
             src="https://cdnjs.cloudflare.com/ajax/libs/howler/2.2.4/howler.min.js"></script>
         <script src="game.js"></script>


### PR DESCRIPTION
change log:

- Removed "loop" property because Litecanvas automatically detects global functions with the event names (update, draw, tap, etc)
- Removed "pauseOnBlur" property. It no longer exists.
- Use `pal()` to change the color palette.
- The `seed()` was renamed to `rseed()`.
- Update the `clip()` calls. Now the path must be manipulated in a callback.
- The variable`ELAPSED` was renamed to just `T`.